### PR TITLE
Wrap memo handling in if block

### DIFF
--- a/swi/views/navigation.php
+++ b/swi/views/navigation.php
@@ -1,13 +1,14 @@
 		<?php if ($this->session->userdata('is_authed')) : ?>
 		
 		<?php
-			if ($this->config->item('atheme_memoserv'))
+			if ($this->config->item('atheme_memoserv')) {
 				$mdata = $this->memoserv_model->get_memos(TRUE);
 				
-			if (preg_match('/\((.*) new\)/sm', $mdata['data'], $regs))
-				$new_memos = $regs[1];
-			else
-				$new_memos = FALSE;	
+				if (preg_match('/\((.*) new\)/sm', $mdata['data'], $regs))
+					$new_memos = $regs[1];
+				else
+					$new_memos = FALSE;
+			}
 		?>
 		
 		<!-- primary navigation -->


### PR DESCRIPTION
The block should be wrapped in the if { ... } otherwise invalid access to unset mdata variable happens.  More or less, trying to execute memo handling even if memoserv was disabled in the config.  