### PR TITLE
remove color from body style

### DIFF
--- a/style.css
+++ b/style.css
@@ -57,7 +57,6 @@ body {
   font-family: 'Tahoma', sans-serif;
   font-size: 12px;
   height: 100%;
-  color:FFFFFF;
 }
 
 a { color: #335FA0; text-decoration: none; }


### PR DESCRIPTION
white text on light gray background makes some text elements essentially unreadable. Removing it and using the default black color is much more eye friendly